### PR TITLE
Feature multiple context Closed #20

### DIFF
--- a/demo/AspNetCore5.0/Controllers/EmployeeController.cs
+++ b/demo/AspNetCore5.0/Controllers/EmployeeController.cs
@@ -15,17 +15,20 @@ namespace AspNetCore5._0.Controllers
     public class EmployeeController : Controller
     {
         private readonly IRepository _repository;
+        private readonly IMultipleRepository<DemoDbContext2> _multipleRepository2;
         private readonly IQueryRepository _queryRepository;
         private readonly DemoDbContext _context;
 
         public EmployeeController(
             IRepository repository,
             IQueryRepository queryRepository,
-            DemoDbContext context)
+            DemoDbContext context, 
+            IMultipleRepository<DemoDbContext2> multipleRepository2)
         {
             _repository = repository;
             _context = context;
             _queryRepository = queryRepository;
+            _multipleRepository2 = multipleRepository2;
         }
 
         // GET: Employee
@@ -38,6 +41,9 @@ namespace AspNetCore5._0.Controllers
             string sqlQuery = "Select EmployeeName, DepartmentName from Employee Where EmployeeName LIKE @p0 + '%' and DepartmentName LIKE @p1 + '%'";
             List<EmployeeDto> items = await _repository
                 .GetFromRawSqlAsync<EmployeeDto>(sqlQuery, search);
+
+            List<EmployeeDto> items2 = await _multipleRepository2
+               .GetFromRawSqlAsync<EmployeeDto>(sqlQuery, search);
 
             //List<string> list1 = _context.ExecSQL<string>("Select EmployeeName from Employee");
             List<Employee> lists = await _queryRepository.GetQueryable<Employee>().ToListAsync();

--- a/demo/AspNetCore5.0/Data/DemoDbContext.cs
+++ b/demo/AspNetCore5.0/Data/DemoDbContext.cs
@@ -25,4 +25,26 @@ namespace AspNetCore5._0.Data
         public DbSet<Employee> Employee { get; set; }
         public DbSet<EmployeeHistory> EmployeeHistories { get; set; }
     }
+
+    public class DemoDbContext2 : DbContext
+    {
+        public DemoDbContext2(DbContextOptions<DemoDbContext2> options) : base(options)
+        {
+
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            if (modelBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(modelBuilder));
+            }
+
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<Employee>().HasKey(e => e.EmployeeId);
+        }
+
+        public DbSet<Employee> Employee { get; set; }
+        public DbSet<EmployeeHistory> EmployeeHistories { get; set; }
+    }
 }

--- a/demo/AspNetCore5.0/Startup.cs
+++ b/demo/AspNetCore5.0/Startup.cs
@@ -25,8 +25,11 @@ namespace AspNetCore5._0
             services.AddServicesOfAllTypes();
             string connectionString = Configuration.GetConnectionString("RepositoryDbConnection");
             services.AddDbContext<DemoDbContext>(option => option.UseSqlServer(connectionString));
+            services.AddDbContext<DemoDbContext2>(option => option.UseSqlServer(connectionString));
 
             services.AddGenericRepository<DemoDbContext>(); // Call it just after registering your DbConext.
+            services.AddGenericMultipleRepository<DemoDbContext2>(); // Call it just after registering your DbConext.
+
             services.AddQueryRepository<DemoDbContext>();
 
             services.AddControllersWithViews();

--- a/src/TanvirArjel.EFCore.GenericRepository/IBaseRepository.cs
+++ b/src/TanvirArjel.EFCore.GenericRepository/IBaseRepository.cs
@@ -1,0 +1,118 @@
+﻿// <copyright file="IRepository.cs" company="TanvirArjel">
+// Copyright (c) TanvirArjel. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace TanvirArjel.EFCore.GenericRepository
+{
+    /// <summary>
+    /// Contains all the repository methods.
+    /// </summary>
+    public interface IBaseRepository : IQueryRepository
+    {
+        /// <summary>
+        /// Begin a new database transaction.
+        /// </summary>
+        /// <param name="isolationLevel"><see cref="IsolationLevel"/> to be applied on this transaction. (Default to <see cref="IsolationLevel.Unspecified"/>).</param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+        /// <returns>Returns a <see cref="IDbContextTransaction"/> instance.</returns>
+        Task<IDbContextTransaction> BeginTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.Unspecified,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// This method takes <typeparamref name="TEntity"/>, insert it into database and returns <see cref="Task{TResult}"/>.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="entity">The entity to be inserted.</param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+        /// <returns>Returns <see cref="Task"/>.</returns>
+        Task<object[]> InsertAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+            where TEntity : class;
+
+        /// <summary>
+        /// This method takes <typeparamref name="TEntity"/>, insert it into the database and returns <see cref="Task"/>.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="entities">The entities to be inserted.</param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+        /// <returns>Returns <see cref="Task"/>.</returns>
+        Task InsertAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+            where TEntity : class;
+
+        /// <summary>
+        /// This method takes <typeparamref name="TEntity"/>, send update operation to the database and returns <see cref="void"/>.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="entity">The entity to be updated.</param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+        /// <returns>Returns <see cref="Task"/>.</returns>
+        Task<int> UpdateAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+            where TEntity : class;
+
+        /// <summary>
+        /// This method takes <see cref="IEnumerable{TEntity}"/> of entities, send update operation to the database and returns <see cref="void"/>.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="entities">The entities to be updated.</param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+        /// <returns>Returns <see cref="Task"/>.</returns>
+        Task<int> UpdateAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+            where TEntity : class;
+
+        /// <summary>
+        /// This method takes an entity of type <typeparamref name="TEntity"/>, delete the entity from database and returns <see cref="void"/>.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="entity">The entity to be deleted.</param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+        /// <returns>Returns <see cref="Task"/>.</returns>
+        Task<int> DeleteAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+            where TEntity : class;
+
+        /// <summary>
+        /// This method takes <see cref="IEnumerable{T}"/> of entities, delete those entities from database and returns <see cref="void"/>.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="entities">The list of entities to be deleted.</param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+        /// <returns>Returns <see cref="Task"/>.</returns>
+        Task<int> DeleteAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+            where TEntity : class;
+
+        /// <summary>
+        /// Execute raw sql command against the configured database asynchronously.
+        /// </summary>
+        /// <param name="sql">The sql string.</param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+        /// <returns>Returns <see cref="Task{TResult}"/>.</returns>
+        Task<int> ExecuteSqlCommandAsync(string sql, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Execute raw sql command against the configured database asynchronously.
+        /// </summary>
+        /// <param name="sql">The sql string.</param>
+        /// <param name="parameters">The paramters in the sql string.</param>
+        /// <returns>Returns <see cref="Task{TResult}"/>.</returns>
+        Task<int> ExecuteSqlCommandAsync(string sql, params object[] parameters);
+
+        /// <summary>
+        /// Execute raw sql command against the configured database asynchronously.
+        /// </summary>
+        /// <param name="sql">The sql string.</param>
+        /// <param name="parameters">The paramters in the sql string.</param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+        /// <returns>Returns <see cref="Task{TResult}"/>.</returns>
+        Task<int> ExecuteSqlCommandAsync(string sql, IEnumerable<object> parameters, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Reset the DbContext state by removing all the tracked and attached entities.
+        /// </summary>
+        void ResetContextState();
+    }
+}

--- a/src/TanvirArjel.EFCore.GenericRepository/IMultipleRepository.cs
+++ b/src/TanvirArjel.EFCore.GenericRepository/IMultipleRepository.cs
@@ -13,8 +13,9 @@ namespace TanvirArjel.EFCore.GenericRepository
     /// <summary>
     /// Contains all the repository methods.
     /// </summary>
-    public interface IRepository : IBaseRepository
+    /// <typeparam name="TContext">For Multiple Context Support</typeparam>
+    public interface IMultipleRepository<TContext>: IBaseRepository
     {
-       
+     
     }
 }

--- a/src/TanvirArjel.EFCore.GenericRepository/Repository.cs
+++ b/src/TanvirArjel.EFCore.GenericRepository/Repository.cs
@@ -15,11 +15,11 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace TanvirArjel.EFCore.GenericRepository
 {
-    internal class Repository : QueryRepository, IRepository
+    internal class Repository<TContext> : QueryRepository<TContext>, IRepository,IMultipleRepository<TContext> where TContext : DbContext
     {
-        private readonly DbContext _dbContext;
+        private readonly TContext _dbContext;
 
-        public Repository(DbContext dbContext)
+        public Repository(TContext dbContext)
             : base(dbContext)
         {
             _dbContext = dbContext;

--- a/src/TanvirArjel.EFCore.GenericRepository/ServiceCollectionExtensions.cs
+++ b/src/TanvirArjel.EFCore.GenericRepository/ServiceCollectionExtensions.cs
@@ -36,7 +36,37 @@ namespace TanvirArjel.EFCore.GenericRepository
                 serviceProvider =>
                 {
                     TDbContext dbContext = ActivatorUtilities.CreateInstance<TDbContext>(serviceProvider);
-                    return new Repository(dbContext);
+                    return new Repository<TDbContext>(dbContext);
+                },
+                lifetime));
+
+            return services;
+        }
+
+        /// <summary>
+        /// Add generic repository services to the .NET Dependency Injection container.
+        /// </summary>
+        /// <typeparam name="TDbContext">Your EF Core <see cref="DbContext"/>.</typeparam>
+        /// <param name="services">The type to be extended.</param>
+        /// <param name="lifetime">The life time of the service.</param>
+        /// <returns>Retruns <see cref="IServiceCollection"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="services"/> is <see langword="null"/>.</exception>
+        public static IServiceCollection AddGenericMultipleRepository<TDbContext>(
+            this IServiceCollection services,
+            ServiceLifetime lifetime = ServiceLifetime.Scoped)
+            where TDbContext : DbContext
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.Add(new ServiceDescriptor(
+                typeof(IMultipleRepository<TDbContext>),
+                serviceProvider =>
+                {
+                    TDbContext dbContext = ActivatorUtilities.CreateInstance<TDbContext>(serviceProvider);
+                    return new Repository<TDbContext>(dbContext);
                 },
                 lifetime));
 

--- a/src/TanvirArjel.EFCore.QueryRepository/QueryRepository.cs
+++ b/src/TanvirArjel.EFCore.QueryRepository/QueryRepository.cs
@@ -20,11 +20,11 @@ using Microsoft.EntityFrameworkCore.Query;
 
 namespace TanvirArjel.EFCore.GenericRepository
 {
-    internal class QueryRepository : IQueryRepository
+    internal class QueryRepository<TContext> : IQueryRepository where TContext : DbContext
     {
-        private readonly DbContext _dbContext;
+        private readonly TContext _dbContext;
 
-        public QueryRepository(DbContext dbContext)
+        public QueryRepository(TContext dbContext)
         {
             _dbContext = dbContext;
         }

--- a/src/TanvirArjel.EFCore.QueryRepository/ServiceCollectionExtensions.cs
+++ b/src/TanvirArjel.EFCore.QueryRepository/ServiceCollectionExtensions.cs
@@ -37,7 +37,7 @@ namespace TanvirArjel.EFCore.GenericRepository
                 {
                     TDbContext dbContext = ActivatorUtilities.CreateInstance<TDbContext>(serviceProvider);
                     dbContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
-                    return new QueryRepository(dbContext);
+                    return new QueryRepository<TDbContext>(dbContext);
                 },
                 lifetime));
 


### PR DESCRIPTION
Multiple database usage while previous versions continue to support.

Example:

```
  services.AddDbContext<DemoDbContext>(option => option.UseSqlServer(connectionString)); //default
  services.AddDbContext<DemoDbContext2>(option => option.UseSqlServer(connectionString)); //optional for multiple
```

```
   services.AddGenericRepository<DemoDbContext>(); // default
   services.AddGenericMultipleRepository<DemoDbContext2>(); // if you want multiple
```


```
   private readonly IRepository _repository; //default
   private readonly IMultipleRepository<DemoDbContext2> _multipleRepository2; //multiple
```