### PR TITLE
Added GetByIdAsync with additional conditions, fixed typo

### DIFF
--- a/src/TanvirArjel.EFCore.QueryRepository/IQueryRepository.cs
+++ b/src/TanvirArjel.EFCore.QueryRepository/IQueryRepository.cs
@@ -42,7 +42,7 @@ namespace TanvirArjel.EFCore.GenericRepository
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="asNoTracking">A <see cref="bool"/> value which determines whether the return entity will be tracked by
-        /// EF Core context or not. Defualt value is false i.e trackig is enabled by default.
+        /// EF Core context or not. Default value is false i.e tracking is enabled by default.
         /// </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns <see cref="Task"/> of <see cref="List{T}"/>.</returns>
@@ -67,7 +67,7 @@ namespace TanvirArjel.EFCore.GenericRepository
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="includes">Navigation properties to be loaded.</param>
         /// <param name="asNoTracking">A <see cref="bool"/> value which determines whether the return entity will be tracked by
-        /// EF Core context or not. Defualt value is false i.e trackig is enabled by default.
+        /// EF Core context or not. Default value is false i.e tracking is enabled by default.
         /// </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns <see cref="Task"/> of <see cref="List{T}"/>.</returns>
@@ -93,7 +93,7 @@ namespace TanvirArjel.EFCore.GenericRepository
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="condition">The condition on which entity list will be returned.</param>
         /// <param name="asNoTracking">A <see cref="bool"/> value which determines whether the return entity will be tracked by
-        /// EF Core context or not. Defualt value is false i.e trackig is enabled by default.
+        /// EF Core context or not. Default value is false i.e tracking is enabled by default.
         /// </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns <see cref="List{TEntity}"/>.</returns>
@@ -110,7 +110,7 @@ namespace TanvirArjel.EFCore.GenericRepository
         /// <param name="condition">The condition on which entity list will be returned.</param>
         /// <param name="includes">Navigation properties to be loaded.</param>
         /// <param name="asNoTracking">A <see cref="bool"/> value which determines whether the return entity will be tracked by
-        /// EF Core context or not. Defualt value is false i.e trackig is enabled by default.
+        /// EF Core context or not. Default value is false i.e tracking is enabled by default.
         /// </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns <see cref="List{TEntity}"/>.</returns>
@@ -141,7 +141,7 @@ namespace TanvirArjel.EFCore.GenericRepository
         /// on which data will be returned.
         /// </param>
         /// <param name="asNoTracking">A <see cref="bool"/> value which determines whether the return entity will be tracked by
-        /// EF Core context or not. Defualt value is false i.e trackig is enabled by default.
+        /// EF Core context or not. Default value is false i.e tracking is enabled by default.
         /// </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns <see cref="List{TEntity}"/>.</returns>
@@ -245,7 +245,7 @@ namespace TanvirArjel.EFCore.GenericRepository
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="id">The primary key value of the entity.</param>
         /// <param name="asNoTracking">A <see cref="bool"/> value which determines whether the return entity will be tracked by
-        /// EF Core context or not. Defualt value is false i.e trackig is enabled by default.
+        /// EF Core context or not. Default value is false i.e tracking is enabled by default.
         /// </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns <see cref="Task{TResult}"/>.</returns>
@@ -275,7 +275,7 @@ namespace TanvirArjel.EFCore.GenericRepository
         /// <param name="id">The primary key value of the entity.</param>
         /// <param name="includes">The navigation properties to be loaded.</param>
         /// <param name="asNoTracking">A <see cref="bool"/> value which determines whether the return entity will be tracked by
-        /// EF Core context or not. Defualt value is false i.e trackig is enabled by default.
+        /// EF Core context or not. Default value is false i.e tracking is enabled by default.
         /// </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns <see cref="Task{TResult}"/>.</returns>
@@ -304,6 +304,27 @@ namespace TanvirArjel.EFCore.GenericRepository
             where TEntity : class;
 
         /// <summary>
+        /// This method takes <paramref name="id"/> which is the primary key value of the entity with additional conditions
+        /// and returns the entity if found otherwise <see langword="null"/>.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="id">The primary key value of the entity.</param>
+        /// <param name="conditions">The additional conditions based on which entity will be returned.</param>
+        /// <param name="includes">Navigation properties to be loaded.</param>
+        /// <param name="asNoTracking">A <see cref="bool"/> value which determines whether the return entity will be tracked by
+        /// EF Core context or not. Default value is false i.e tracking is enabled by default.
+        /// </param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+        /// <returns>Returns <see cref="Task{TResult}"/>.</returns>
+        Task<TEntity> GetByIdAsync<TEntity>(
+            object id,
+            IEnumerable<Expression<Func<TEntity, bool>>> conditions,
+            Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includes,
+            bool asNoTracking,
+            CancellationToken cancellationToken = default)
+            where TEntity : class;
+
+        /// <summary>
         /// This method takes <see cref="Expression{Func}"/> as parameter and returns <typeparamref name="TEntity"/>.
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
@@ -319,7 +340,7 @@ namespace TanvirArjel.EFCore.GenericRepository
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="condition">The conditon on which entity will be returned.</param>
         /// <param name="asNoTracking">A <see cref="bool"/> value which determines whether the return entity will be tracked by
-        /// EF Core context or not. Defualt value is false i.e trackig is enabled by default.
+        /// EF Core context or not. Default value is false i.e tracking is enabled by default.
         /// </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns <typeparamref name="TEntity"/>.</returns>
@@ -350,7 +371,7 @@ namespace TanvirArjel.EFCore.GenericRepository
         /// <param name="condition">The conditon on which entity will be returned.</param>
         /// <param name="includes">Navigation properties to be loaded.</param>
         /// <param name="asNoTracking">A <see cref="bool"/> value which determines whether the return entity will be tracked by
-        /// EF Core context or not. Defualt value is false i.e trackig is enabled by default.
+        /// EF Core context or not. Default value is false i.e tracking is enabled by default.
         /// </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns <typeparamref name="TEntity"/>.</returns>
@@ -381,7 +402,7 @@ namespace TanvirArjel.EFCore.GenericRepository
         /// on which data will be returned.
         /// </param>
         /// <param name="asNoTracking">A <see cref="bool"/> value which determines whether the return entity will be tracked by
-        /// EF Core context or not. Defualt value is false i.e trackig is enabled by default.
+        /// EF Core context or not. Default value is false i.e tracking is enabled by default.
         /// </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>Returns <see cref="Task{TResult}"/>.</returns>

--- a/src/TanvirArjel.EFCore.QueryRepository/QueryRepository.cs
+++ b/src/TanvirArjel.EFCore.QueryRepository/QueryRepository.cs
@@ -391,6 +391,65 @@ namespace TanvirArjel.EFCore.GenericRepository
                 .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
         }
 
+        public async Task<T> GetByIdAsync<T>(
+            object id,
+            IEnumerable<Expression<Func<T, bool>>> conditions,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> includes,
+            bool asNoTracking = false,
+            CancellationToken cancellationToken = default)
+            where T : class
+        {
+            if (id == null)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            IEntityType entityType = _dbContext.Model.FindEntityType(typeof(T));
+
+            string primaryKeyName = entityType.FindPrimaryKey().Properties.Select(p => p.Name).FirstOrDefault();
+            Type primaryKeyType = entityType.FindPrimaryKey().Properties.Select(p => p.ClrType).FirstOrDefault();
+
+            if (primaryKeyName == null || primaryKeyType == null)
+            {
+                throw new ArgumentException("Entity does not have any primary key defined", nameof(id));
+            }
+
+            object primayKeyValue = null;
+
+            try
+            {
+                primayKeyValue = Convert.ChangeType(id, primaryKeyType, CultureInfo.InvariantCulture);
+            }
+            catch (Exception)
+            {
+                throw new ArgumentException($"You can not assign a value of type {id.GetType()} to a property of type {primaryKeyType}");
+            }
+
+            ParameterExpression pe = Expression.Parameter(typeof(T), "entity");
+            MemberExpression me = Expression.Property(pe, primaryKeyName);
+            ConstantExpression constant = Expression.Constant(primayKeyValue, primaryKeyType);
+            BinaryExpression body = Expression.Equal(me, constant);
+            Expression<Func<T, bool>> expressionTree = Expression.Lambda<Func<T, bool>>(body, new[] { pe });
+
+            IQueryable<T> query = _dbContext.Set<T>();
+
+            var specification = new SpecificationBase<T>
+            {
+                Conditions = conditions.ToList(),
+                Includes = includes,
+            };
+
+            query = query.GetSpecifiedQuery(specification);
+
+            if (asNoTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
+            T enity = await query.FirstOrDefaultAsync(expressionTree, cancellationToken).ConfigureAwait(false);
+            return enity;
+        }
+
         public Task<T> GetAsync<T>(
             Expression<Func<T, bool>> condition,
             CancellationToken cancellationToken = default)


### PR DESCRIPTION
- Added overload for GetByIdAsync to take additional conditions, would be useful for scenarios where the item of the given ID exists, but should not be retrieved, as it may be marked inactive or it belongs to a different tenant, etc.
- Fixed some typos in the comments.